### PR TITLE
Set up Project.toml's of subpackages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,17 +21,3 @@ Graphs = "1.10"
 LinearAlgebra = "1.9"
 PrecompileTools = "1.2"
 julia = "1.9"
-
-[extras]
-ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
-JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-examples = ["ImageIO", "ImageMagick", "ImageShow", "Images", "Plots"]
-lint = ["JuliaFormatter"]
-test = ["Test"]

--- a/data/Project.toml
+++ b/data/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+QuantumStateTransfer = "34a31443-0e20-4b48-9031-55d81b0a9864"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 QuantumStateTransfer = "34a31443-0e20-4b48-9031-55d81b0a9864"
 
 [compat]
 Documenter = "1.5"
-Graphs = "1.10"
 julia = "1.9"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+QuantumStateTransfer = "34a31443-0e20-4b48-9031-55d81b0a9864"

--- a/lint/Project.toml
+++ b/lint/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
+QuantumStateTransfer = "34a31443-0e20-4b48-9031-55d81b0a9864"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+QuantumStateTransfer = "34a31443-0e20-4b48-9031-55d81b0a9864"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Using pkg mode in the REPL, set up, updated, and instantiates the Project.toml's of the examples, lint, and test subpackages. Also, added and initialized a new data subpackage for numerical tests on small graphs and graph families of interest.