### PR TITLE
Closes #8 - Start setting up `results/` folder; save some data

### DIFF
--- a/data/Project.toml
+++ b/data/Project.toml
@@ -1,4 +1,0 @@
-[deps]
-Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-QuantumStateTransfer = "34a31443-0e20-4b48-9031-55d81b0a9864"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,22 +2,19 @@ using QuantumStateTransfer
 using Documenter
 
 DocMeta.setdocmeta!(
-    QuantumStateTransfer,
-    :DocTestSetup,
-    :(using QuantumStateTransfer);
-    recursive = true,
+    QuantumStateTransfer, :DocTestSetup, :(using QuantumStateTransfer); recursive=true
 )
 
 makedocs(;
-    modules = [QuantumStateTransfer],
-    authors = "Luis M. B. Varona <lbvarona@mta.ca>, Nathaniel Johnston <njohnston@mta.ca>",
-    sitename = "QuantumStateTransfer.jl",
-    format = Documenter.HTML(;
-        canonical = "https://GraphQuantum.github.io/QuantumStateTransfer.jl",
-        edit_link = "main",
-        assets = String[],
+    modules=[QuantumStateTransfer],
+    authors="Luis M. B. Varona <lbvarona@mta.ca>, Nathaniel Johnston <njohnston@mta.ca>",
+    sitename="QuantumStateTransfer.jl",
+    format=Documenter.HTML(;
+        canonical="https://GraphQuantum.github.io/QuantumStateTransfer.jl",
+        edit_link="main",
+        assets=String[],
     ),
-    pages = ["Home" => "index.md"],
+    pages=["Home" => "index.md"],
 )
 
-deploydocs(; repo = "github.com/GraphQuantum/QuantumStateTransfer.jl", devbranch = "main")
+deploydocs(; repo="github.com/GraphQuantum/QuantumStateTransfer.jl", devbranch="main")

--- a/examples/optimized_state_transfer/optimized_state_transfer.jl
+++ b/examples/optimized_state_transfer/optimized_state_transfer.jl
@@ -1,7 +1,6 @@
 using QuantumStateTransfer: optimized_state_transfer
 using Graphs
 
-
 """
     hypercube_graph(n::Int)
 
@@ -20,17 +19,16 @@ function hypercube_graph(n::Int)
     hc = Graph(1)
     k2 = complete_graph(2)
 
-    for _ = 1:n
+    for _ in 1:n
         hc = cartesian_product(hc, k2)
     end
 
     return hc
 end
 
-
 N = 4
 
-for n = 1:N
+for n in 1:N
     hc = hypercube_graph(n)
     @info "Data on state transfer on the $n-hypercube:"
 
@@ -42,7 +40,6 @@ for n = 1:N
 
     println()
 end
-
 
 n = 19
 p = 0.63

--- a/examples/path_graphs/path_graphs.jl
+++ b/examples/path_graphs/path_graphs.jl
@@ -3,7 +3,7 @@ using QuantumStateTransfer: QubitPairTransfer, optimized_state_transfer
 using Graphs: adjacency_matrix, edges, path_graph
 
 function qpt_to_string(qpt::QubitPairTransfer)
-    round5(x::Float64) = round(x, digits = 5)
+    round5(x::Float64) = round(x, digits=5)
     return "$(qpt.source) -> $(qpt.dest) with fidelity " *
            "$(round5(qpt.maximum_fidelity)) at time $(round5(qpt.optimal_time))"
 end
@@ -15,14 +15,13 @@ open(dest, "w+") do f
     write(f, "Path Graph Data\n\n")
 end
 
-for n = 2:N
+for n in 2:N
     g = path_graph(n)
-    @time qpts =
-        collect(optimized_state_transfer(g, max_time = 1000, tol = 0.05).qubit_pairs)
+    @time qpts = collect(optimized_state_transfer(g, max_time=1000, tol=0.05).qubit_pairs)
     best_fidelity = maximum(map(qpt -> qpt.maximum_fidelity, qpts))
 
     function criteria(qpt::QubitPairTransfer)
-        return isapprox(qpt.maximum_fidelity, best_fidelity, atol = 1e-2, rtol = 1e-5)
+        return isapprox(qpt.maximum_fidelity, best_fidelity; atol=1e-2, rtol=1e-5)
     end
 
     best_pairs = filter(criteria, qpts)

--- a/examples/unitary_evolution/unitary_evolution.jl
+++ b/examples/unitary_evolution/unitary_evolution.jl
@@ -5,7 +5,6 @@ using FileIO
 using ImageIO, ImageMagick, ImageShow, Images
 using Plots, Plots.PlotMeasures
 
-
 """
     plot_c4_amplitudes(c4_evolution::UnitaryEvolution, source::Int)
 
@@ -30,29 +29,28 @@ function plot_c4_amps(c4_evolution::UnitaryEvolution, source::Int)
     amplitude_plot = plot(
         time_steps,
         real.(transfer_amplitudes),
-        imag.(transfer_amplitudes),
-        xlabel = "Time",
-        ylabel = "Real",
-        zlabel = "Imaginary",
-        labels = labels,
-        title = "Transfer Amplitude from Node $source on the Cycle Graph C₄",
-        lc = lc,
-        lw = lw,
-        la = la,
-        legend = (0.8, 0.8),
-        titlelocation = (0.48, 0.96),
-        top_margin = -35px,
-        bottom_margin = -55px,
-        left_margin = -35px,
-        size = (640, 640),
-        dpi = 300,
+        imag.(transfer_amplitudes);
+        xlabel="Time",
+        ylabel="Real",
+        zlabel="Imaginary",
+        labels=labels,
+        title="Transfer Amplitude from Node $source on the Cycle Graph C₄",
+        lc=lc,
+        lw=lw,
+        la=la,
+        legend=(0.8, 0.8),
+        titlelocation=(0.48, 0.96),
+        top_margin=-35px,
+        bottom_margin=-55px,
+        left_margin=-35px,
+        size=(640, 640),
+        dpi=300,
     )
 
     io = IOBuffer()
     png(amplitude_plot, io)
     return load(io)[26:1825, 61:1860]
 end
-
 
 """
     plot_c4_fidelities(c4_evolution::UnitaryEvolution, source::Int)
@@ -77,27 +75,26 @@ function plot_c4_fids(c4_evolution::UnitaryEvolution, source::Int)
 
     fidelity_plot = plot(
         time_steps,
-        transfer_fidelities,
-        xlabel = "Time",
-        ylabel = "Fidelity",
-        labels = labels,
-        title = "Transfer Fidelity from Node $source on the Cycle Graph C₄",
-        lc = lc,
-        lw = lw,
-        la = la,
-        legend = (0.88, 1.1),
-        titlelocation = (0.38, 1.1),
-        top_margin = 35px,
-        left_margin = 10px,
-        size = (760, 570),
-        dpi = 300,
+        transfer_fidelities;
+        xlabel="Time",
+        ylabel="Fidelity",
+        labels=labels,
+        title="Transfer Fidelity from Node $source on the Cycle Graph C₄",
+        lc=lc,
+        lw=lw,
+        la=la,
+        legend=(0.88, 1.1),
+        titlelocation=(0.38, 1.1),
+        top_margin=35px,
+        left_margin=10px,
+        size=(760, 570),
+        dpi=300,
     )
 
     io = IOBuffer()
     png(fidelity_plot, io)
     return load(io)
 end
-
 
 # Beginning of the example script
 c4 = cycle_graph(4)
@@ -110,7 +107,7 @@ dest_fids = joinpath(@__DIR__, "cycle_graph_4_plots", "transfer_fids")
 mkpath(dest_amps)
 mkpath(dest_fids)
 
-for u = 1:4
+for u in 1:4
     filename_amps = "c4_transfer_amps_from_node_$u.png"
     filename_fids = "c4_transfer_fids_from_node_$u.png"
     save(joinpath(dest_amps, filename_amps), c4_transfer_amps_plots[u])

--- a/results/Project.toml
+++ b/results/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
+JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+QuantumStateTransfer = "34a31443-0e20-4b48-9031-55d81b0a9864"

--- a/results/README.md
+++ b/results/README.md
@@ -1,0 +1,4 @@
+# QuantumStateTransfer/results
+
+In this directory, we store numerical results obtained by iterating over graphs
+up to a certain number of nodes, optimizing quantum state transfer on each.

--- a/results/src/main.jl
+++ b/results/src/main.jl
@@ -1,0 +1,67 @@
+using QuantumStateTransfer: optimized_state_transfer
+using PyCall: PyObject
+using JLD2, CodecZstd
+
+include("../utils/SageImporter.jl")
+include("../utils/GraphGenerators.jl")
+include("../utils/AdjacencySerialization.jl")
+using .SageImporter: import_sage
+using .GraphGenerators:
+    connected_graphs, connected_regular_graphs, connected_bipartite_graphs
+using .AdjacencySerialization: serialize, deserialize
+
+const CON_THRESHOLD = 9 # 261080
+const REG_THRESHOLD = 13 # 389436
+const BIP_THRESHOLD = 12 # 212780
+
+const COMPRESS_LEVEL = 22 # The maximum for ZstdFrameCompressor
+const ADJ_MATS_DEST = joinpath(dirname(@__FILE__), "../data/adjacency_matrices.jld2")
+
+function main()
+    sage = import_sage()
+
+    if isfile(ADJ_MATS_DEST)
+        println("File already exists at `$ADJ_MATS_DEST``.")
+    else
+        println("Generating adjacency matrices and saving to `$ADJ_MATS_DEST``...")
+        _save_adj_mats(sage)
+    end
+
+    println("Loading adjacency matrices from `$ADJ_MATS_DEST``...")
+    adj_mats_serialized = JLD2.load(ADJ_MATS_DEST)
+    adj_mats = Dict(
+        k_outer => Dict(
+            k_inner => deserialize(v_inner, k_inner) for (k_inner, v_inner) in v_outer
+        ) for (k_outer, v_outer) in adj_mats_serialized
+    )
+
+    _save_qst_results(sage) # TODO: Still under development
+end
+
+function _save_adj_mats(sage::PyObject)
+    mkpath(dirname(ADJ_MATS_DEST))
+
+    connected = Dict(
+        n => serialize(map(BitMatrix, connected_graphs(n, sage))) for n in 1:CON_THRESHOLD
+    )
+    con_regular = Dict(
+        n => serialize(map(BitMatrix, connected_regular_graphs(n, sage))) for
+        n in (CON_THRESHOLD + 1):REG_THRESHOLD
+    )
+    con_bipartite = Dict(
+        n => serialize(map(BitMatrix, connected_bipartite_graphs(n, sage))) for
+        n in (REG_THRESHOLD + 1):BIP_THRESHOLD
+    )
+
+    jldopen(ADJ_MATS_DEST, "w"; compress=ZstdFrameCompressor(; level=COMPRESS_LEVEL)) do f
+        f["connected"] = connected
+        f["con_regular"] = con_regular
+        f["con_bipartite"] = con_bipartite
+    end
+end
+
+function _save_qst_results(sage::PyObject)
+    # TODO: Iterate over all adjacency matrices and optimize state transfer, saving results
+end
+
+main()

--- a/results/utils/AdjacencySerialization.jl
+++ b/results/utils/AdjacencySerialization.jl
@@ -1,0 +1,13 @@
+module AdjacencySerialization
+
+export serialize, deserialize
+
+function serialize(mats::Vector{BitMatrix})::BitVector
+    return collect(Iterators.flatten(Iterators.flatten(mats)))
+end
+
+function deserialize(vec::BitVector, k::Int)::Vector{BitMatrix}
+    return map(slice -> Matrix(reshape(slice, k, k)), Iterators.partition(vec, k^2))
+end
+
+end

--- a/results/utils/GraphGenerators.jl
+++ b/results/utils/GraphGenerators.jl
@@ -1,0 +1,35 @@
+module GraphGenerators
+
+using PyCall
+
+export connected_graphs, connected_regular_graphs, connected_bipartite_graphs
+
+_sage_graph_to_adj_mat(g::PyObject) = g.adjacency_matrix().numpy()
+
+function connected_graphs(order::Int, sage::PyObject)
+    graph_gen = sage.graphs.nauty_geng("$order -c -l")
+    return Iterators.map(_sage_graph_to_adj_mat, graph_gen)
+end
+
+function connected_regular_graphs(order::Int, sage::PyObject)
+    valid_degrees = if order == 1
+        0:0 # The only degree-1 graph has no edges and is trivially regular
+    elseif order == 2
+        1:1 # The only connected degree-2 graph has one edge and is regular
+    elseif order % 2 == 0
+        2:(order - 1) # For even-ordered graphs, any `k` allows `k`-regularity`
+    else
+        2:2:(order - 1) # For odd-ordered graphs, only even `k`'s allow for `k`-regularity
+    end
+
+    graph_gens = map(k -> sage.graphs.nauty_geng("$order -c -l -d$k -D$k"), valid_degrees)
+    graph_gen = py"(g for gen in $graph_gens for g in gen)"
+    return Iterators.map(_sage_graph_to_adj_mat, graph_gen)
+end
+
+function connected_bipartite_graphs(order::Int, sage::PyObject)
+    graph_gen = sage.graphs.nauty_geng("$order -c -l -b")
+    return Iterators.map(_sage_graph_to_adj_mat, graph_gen)
+end
+
+end

--- a/results/utils/SageImporter.jl
+++ b/results/utils/SageImporter.jl
@@ -1,0 +1,31 @@
+module SageImporter
+
+using Conda
+using PyCall: pyimport
+
+const ENV_NAME = "sage_env"
+const CONDA_PATH = joinpath(Conda.PYTHONDIR, "conda")
+const ENV_PATH = joinpath(dirname(Conda.PYTHONDIR), "envs", ENV_NAME)
+const PYTHON_EXE = joinpath(ENV_PATH, "bin", "python")
+
+export import_sage
+
+function import_sage()
+    ENV["PYTHON"] = PYTHON_EXE
+    isdir(ENV_PATH) || Conda.create(Symbol(ENV_NAME))
+    packages = read(`$CONDA_PATH list -n $ENV_NAME`, String)
+    occursin(r"(?m)^\s*sage\s+", packages) || Conda.add("sage", Symbol(ENV_NAME))
+
+    try
+        sage = pyimport("sage.all")
+        println("SageMath imported successfully.")
+        return sage
+    catch # The conda environment might not be properly initialized at first
+        println("Failed to import SageMath. Initializing conda environment...")
+        sage = pyimport("sage.all")
+        println("SageMath imported successfully after initialization.")
+        return sage
+    end
+end
+
+end

--- a/src/ErrorMessages.jl
+++ b/src/ErrorMessages.jl
@@ -2,21 +2,20 @@ module ErrorMessages
 
 module QuantumStateTransfer
 
-export ADJ_MAT_ERR
+    export ADJ_MAT_ERR
 
-const ADJ_MAT_ERR = "Adjacency matrix must be symmetric"
+    const ADJ_MAT_ERR = "Adjacency matrix must be symmetric"
 # TODO: I'm sure there will be more...
 
 end # module QuantumStateTransfer
 
-
 module ShubertPiyavskii
 
-export LIPSCHITZ_ERR, OPTIM_RANGE_ERR, TOL_ERR
+    export LIPSCHITZ_ERR, OPTIM_RANGE_ERR, TOL_ERR
 
-const LIPSCHITZ_ERR = "Lipschitz constant must be non-negative"
-const OPTIM_RANGE_ERR = "Optimization range must be non-empty"
-const TOL_ERR = "Tolerance must be positive"
+    const LIPSCHITZ_ERR = "Lipschitz constant must be non-negative"
+    const OPTIM_RANGE_ERR = "Optimization range must be non-empty"
+    const TOL_ERR = "Tolerance must be positive"
 
 end # module ShubertPiyavskii
 

--- a/src/QuantumStateTransfer/optimized_state_transfer.jl
+++ b/src/QuantumStateTransfer/optimized_state_transfer.jl
@@ -3,7 +3,6 @@ const MAX_TIME = 4π
 # TODO: Another "standard" option is 1e-5... but SP runs too slow then. Decide?
 const DEFAULT_TOL = 0.01
 
-
 """
     OptimizedStateTransfer
 
@@ -26,13 +25,12 @@ function Base.show(io::IO, ost::OptimizedStateTransfer)
     buffer = IOBuffer()
     show(IOContext(buffer), "text/plain", ost.adjacency_matrix)
     s1 = String(take!(buffer));
-    s1 = s1[1:(findfirst(isequal(':'), s1)-1)]
+    s1 = s1[1:(findfirst(isequal(':'), s1) - 1)]
     s2 = ost.exhibits_pst
     s3 = "QubitPairTransfer Base.Generator"
     out = "OptimizedStateTransfer($s1, $s2, $s3)"
     print(io, out)
 end
-
 
 """
     QubitPairTransfer
@@ -58,11 +56,10 @@ end
 
 function Base.show(io::IO, qpt::QubitPairTransfer)
     (s1, s2, s3) = (qpt.source, qpt.dest, qpt.is_pst)
-    (s4, s5) = round.([qpt.maximum_fidelity, qpt.optimal_time], digits = 5)
+    (s4, s5) = round.([qpt.maximum_fidelity, qpt.optimal_time]; digits=5)
     out = "QubitPairTransfer($s1, $s2, $s3, $s4, $s5)"
     print(io, out)
 end
-
 
 # TODO: Finalize docstring
 """
@@ -88,9 +85,10 @@ Add later
 """
 function optimized_state_transfer(adj_mat::AbstractMatrix{<:Real}; kwargs...)
     n = size(adj_mat, 1)
-    uvs = [(u, v) for u = 1:(n-1) for v = (u+1):n]
-    qubit_pairs =
-        Base.Generator(uv -> qubit_pair_transfer(adj_mat, uv[1], uv[2]; kwargs...), uvs)
+    uvs = [(u, v) for u in 1:(n - 1) for v in (u + 1):n]
+    qubit_pairs = Base.Generator(
+        uv -> qubit_pair_transfer(adj_mat, uv[1], uv[2]; kwargs...), uvs
+    )
     exhibits_pst = any(qpt -> qpt.is_pst, qubit_pairs)
     return OptimizedStateTransfer(adj_mat, exhibits_pst, qubit_pairs)
 end
@@ -100,7 +98,6 @@ end
     adj_mat = MatType(adjacency_matrix(graph))
     return optimized_state_transfer(adj_mat; kwargs...)
 end
-
 
 """
     qubit_pair_transfer(
@@ -154,9 +151,9 @@ function qubit_pair_transfer(
     adj_mat::AbstractMatrix{<:Real},
     source::Int,
     dest::Int;
-    min_time::Real = MIN_TIME,
-    max_time::Real = MAX_TIME,
-    tol::Real = DEFAULT_TOL,
+    min_time::Real=MIN_TIME,
+    max_time::Real=MAX_TIME,
+    tol::Real=DEFAULT_TOL,
 )
     (adj_mat == adj_mat') || throw(DomainError(adj_mat, ADJ_MAT_ERR))
 
@@ -171,7 +168,7 @@ function qubit_pair_transfer(
     upper = Float64(max_time)
     lipschitz = 2 * norm(adj_mat, 2)
 
-    res = maximize_shubert(fidelity, lower, upper, lipschitz; tol = tol)
+    res = maximize_shubert(fidelity, lower, upper, lipschitz; tol=tol)
     maximum_fidelity = res.maximum
     optimal_time = res.maximizer
     is_pst = maximum_fidelity > 1 - tol
@@ -180,10 +177,7 @@ function qubit_pair_transfer(
 end
 
 @inline function qubit_pair_transfer(
-    graph::AbstractGraph{Int},
-    source::Int,
-    dest::Int;
-    kwargs...,
+    graph::AbstractGraph{Int}, source::Int, dest::Int; kwargs...
 )
     MatType = hasproperty(graph, :weights) ? Matrix : BitMatrix
     adj_mat = MatType(adjacency_matrix(graph))

--- a/src/QuantumStateTransfer/precompile_workload.jl
+++ b/src/QuantumStateTransfer/precompile_workload.jl
@@ -8,8 +8,7 @@
 
     @compile_workload begin
         unitary_evolution(g, time_steps)
-        ost =
-            optimized_state_transfer(g; min_time = min_time, max_time = max_time, tol = tol)
+        ost = optimized_state_transfer(g; min_time=min_time, max_time=max_time, tol=tol)
         collect(ost.qubit_pairs) # Eager instantiation of `QubitPairTransfer` structs
     end
 end

--- a/src/QuantumStateTransfer/unitary_evolution.jl
+++ b/src/QuantumStateTransfer/unitary_evolution.jl
@@ -1,6 +1,5 @@
-const TIME_STEPS::StepRangeLen{Float64} = 0:(π/200):5
+const TIME_STEPS::StepRangeLen{Float64} = 0:(π / 200):5
 const TIME_STEPS_STR::String = "0:(π / 200):5"
-
 
 """
     UnitaryEvolution
@@ -22,7 +21,6 @@ struct UnitaryEvolution
     transfer_amplitudes::Array{ComplexF64,3}
     transfer_fidelities::Array{Float64,3}
 end
-
 
 """
     unitary_evolution(
@@ -127,12 +125,10 @@ julia> evolution.transfer_fidelities # State transfer fidelities between qubits
 ```
 """
 function unitary_evolution(
-    adj_mat::AbstractMatrix{<:Real},
-    time_steps::AbstractVector{<:Real} = TIME_STEPS,
+    adj_mat::AbstractMatrix{<:Real}, time_steps::AbstractVector{<:Real}=TIME_STEPS
 )
     amps_vec = map(
-        u -> track_qubit_amplitude(adj_mat, u, time_steps = time_steps),
-        1:size(adj_mat, 1),
+        u -> track_qubit_amplitude(adj_mat, u; time_steps=time_steps), 1:size(adj_mat, 1)
     )
     transfer_amplitudes = stack(amps_vec)
     transfer_fidelities = abs2.(transfer_amplitudes)
@@ -140,14 +136,12 @@ function unitary_evolution(
 end
 
 @inline function unitary_evolution(
-    graph::AbstractGraph{Int},
-    time_steps::AbstractVector{<:Real} = TIME_STEPS,
+    graph::AbstractGraph{Int}, time_steps::AbstractVector{<:Real}=TIME_STEPS
 )
     MatType = hasproperty(graph, :weights) ? Matrix : BitMatrix
     adj_mat = MatType(adjacency_matrix(graph))
     return unitary_evolution(adj_mat, time_steps)
 end
-
 
 """
     track_qubit_amplitude(
@@ -195,8 +189,8 @@ julia> amps_3_to_247 = track_qubit_amplitude(g, source, dests=dests, time_steps=
 function track_qubit_amplitude(
     adj_mat::AbstractMatrix{<:Real},
     source::Int;
-    dests::AbstractVector{Int} = 1:size(adj_mat, 1),
-    time_steps::AbstractVector{<:Real} = TIME_STEPS,
+    dests::AbstractVector{Int}=1:size(adj_mat, 1),
+    time_steps::AbstractVector{<:Real}=TIME_STEPS,
 )
     (adj_mat == adj_mat') || throw(DomainError(adj_mat, ADJ_MAT_ERR))
 

--- a/test/optimized_state_transfer.jl
+++ b/test/optimized_state_transfer.jl
@@ -4,7 +4,6 @@ using Test
 using QuantumStateTransfer: optimized_state_transfer, qubit_pair_transfer
 using Graphs
 
-
 ### TODO: This is just stuff linked to the old API. I'll figure out what to do
 ### with it some other time; anyway, the rest of the test suite is a mess too.
 # C4_adj = BitMatrix([0 1 0 1;
@@ -22,7 +21,6 @@ using Graphs
 # is_optimal_time1(time::Real) = time % 2π ≈ 3π / 4
 # is_optimal_time2(time::Real) = time % 2π ≈ π / 2
 
-
 # @time @testset "qubit_pair_transfer" begin
 #     qpt1 = qubit_pair_transfer(C4_adj, source, dest1)
 #     qpt2 = qubit_pair_transfer(C4_graph, source, dest2)
@@ -32,7 +30,6 @@ using Graphs
 #     @test is_optimal_time1(qpt1.optimal_time)
 #     @test is_optimal_time2(qpt2.optimal_time)
 # end
-
 
 """
     hypercube_graph(n::Int)
@@ -52,13 +49,12 @@ function hypercube_graph(n::Int)
     hc = Graph(1)
     k2 = complete_graph(2)
 
-    for _ = 1:n
+    for _ in 1:n
         hc = cartesian_product(hc, k2)
     end
 
     return hc
 end
-
 
 # TODO: Use matrix power trick for each row instead?
 """
@@ -94,23 +90,23 @@ function hypercube_pst_pairs(n::Int)
             marked[u] = true
             v = findfirst(isequal(n), dijkstra_states[u].dists)
             pair = u < v ? (u, v) : (v, u)
-            marked[v] || (marked[v] = true; push!(pst_pairs, pair))
+            marked[v] || (marked[v]=true; push!(pst_pairs, pair))
         end
     end
 
     return pst_pairs
 end
 
-
 N = 4
 hypercubes = map(hypercube_graph, 1:N)
 pst_pairs_theory = map(hypercube_pst_pairs, 1:N)
 
 @time @testset "optimized_state_transfer" begin
-    for n = 1:N
+    for n in 1:N
         all_pairs = collect(optimized_state_transfer(hypercubes[n]).qubit_pairs)
-        pst_pairs_actual =
-            map(qpt -> (qpt.source, qpt.dest), filter(qpt -> qpt.is_pst, all_pairs))
+        pst_pairs_actual = map(
+            qpt -> (qpt.source, qpt.dest), filter(qpt -> qpt.is_pst, all_pairs)
+        )
         @test pst_pairs_theory[n] == pst_pairs_actual
     end
 end


### PR DESCRIPTION
Renamed the `data/` folder to `results/`, for obtaining data on optimized state transfer for all graphs up to a certain order. Also, began setting up helper modules, and wrote part of the `main.jl` script, using it to save all relevant adjacency matrices, generated by interfacing with SageMath and its interface with `nauty-geng`. (We have all connected graphs up to order 9, all connected regular graphs up to order 13, and all connected bipartite graphs up to order 12.) We may need to refactor the `OptimizedStateTransfer` API a bit before proceeding...