### PR TITLE
Bugfix for state mixing logic

### DIFF
--- a/src/core/state_mixing.jl
+++ b/src/core/state_mixing.jl
@@ -26,7 +26,7 @@ function Base.show(io::IO, res::StateMixingMaximizationResult)
     println(io, " * Time interval: [$(res.t_lower), $(res.t_upper)]")
     println(io, " * Epsilon tolerance: $(res.epsilon)")
     println(io, " * Maximizing time: $(res.maximizer)")
-    println(io, " * Maximum uniformity: $(res.max_mixing)")
+    println(io, " * Maximum uniformity: $(res.max_uniformity)")
 
     return nothing
 end


### PR DESCRIPTION
The Base.show override for the state mixing maximization output struct previously tried to access a 'max_mixing' field, which does not exist. The correct field is 'max_uniformity'.